### PR TITLE
Refactor `Math` check to definition time

### DIFF
--- a/source/function-generator.js
+++ b/source/function-generator.js
@@ -1,9 +1,32 @@
-export default (object, names, rename = {}) =>
-  names.reduce((m, name) => {
-    m[rename[name] || name] = function (...s) {
-      return this.constructor === Array && object === Math ? object[name](...this, ...s) :
-                                                             object[name](this, ...s);
-    };
+export default (object, names, rename = {}) => {
+  const ns = Object.prototype.toString.call(object).slice(8, -1)
 
-    return m;
+  names.reduce((memo, name) => {
+    if (object === Math) {
+      memo[rename[name] || name] = fromMath(object, ns, name)
+    } else {
+      memo[rename[name] || name] = fromOther(object, ns, name)
+    }
+
+    return memo;
   }, {});
+};
+
+function fromMath(object, ns, name) {
+  return function (...rest) {
+    if (this != null) throw new TypeError(`${ns}.${name} called on null or undefined`);
+    if (Array.isArray(this)) {
+      rest = this.concat(rest);
+    } else {
+      rest = [this].concat(rest);
+    }
+    return object[name](...rest)
+  };
+}
+
+function fromOther(object, ns, name) {
+  return function (...rest) {
+    if (this != null) throw new TypeError(`#{ns}.#{name} called on null or undefined`);
+    return object[name](this, ...rest);
+  };
+}


### PR DESCRIPTION
Instead of checking on each call, only perform the `object === Math` once per definition.
